### PR TITLE
Make scroll_into_view account for fixed navbars

### DIFF
--- a/thirtyfour/src/webelement.rs
+++ b/thirtyfour/src/webelement.rs
@@ -673,7 +673,7 @@ impl WebElement {
     /// # }
     /// ```
     pub async fn scroll_into_view(&self) -> WebDriverResult<()> {
-        self.handle.execute(r#"arguments[0].scrollIntoView();"#, vec![self.to_json()?]).await?;
+        self.handle.execute(r#"arguments[0].scrollIntoView({block: "center", inline: "center"});"#, vec![self.to_json()?]).await?;
         Ok(())
     }
 


### PR DESCRIPTION
When the page has a fixed navbar (like in material-ui), and we want to focus a link before clicking it, scroll_into_view may leave the link behind the navbar, therefore not clickable.

This change akes scrollIntoView try to align the element in the center x/y axes of the viewport, ensuring the element is not obscured by fixed navigational elements in the viewport margins.

If scroll_into_view still leaves the element obscured by such navigational elements, then it's likely a user wouldn't be able to do so either, so the UI needs to be fixed.

I propose changing the current scroll_into_view instead of proposing a new method with params because this seems to be a 'scroll_into_view' helper that's supposed to just work.  I don't think this will break any existing test suites, unless the test uses scroll_into_view while having a floating element right in the middle of the page.